### PR TITLE
Fix help text css class for multiple checkbox field

### DIFF
--- a/bulma/templates/bulma/forms/field.html
+++ b/bulma/templates/bulma/forms/field.html
@@ -138,7 +138,7 @@
       {% endfor %}
 
       {% if field.help_text %}
-        <p class="help-block">
+        <p class="help">
           {{ field.help_text|safe }}
         </p>
       {% endif %}


### PR DESCRIPTION
The help text of multiple checkbox field use `help-block`, fixed to `help` css class.