### PR TITLE
Remove delete button from general form error

### DIFF
--- a/bulma/templates/bulma/forms/form.html
+++ b/bulma/templates/bulma/forms/form.html
@@ -1,8 +1,6 @@
 {% if form.non_field_errors %}
   <div class="message is-danger">
-    <div class="message-header">
-      <button class="delete" aria-label="delete"></button>
-    </div>
+    <div class="message-header"></div>
     <div class="message-body">
       {% for non_field_error in form.non_field_errors %}
         {{ non_field_error }}


### PR DESCRIPTION
Since bulma doesn't ship with javascript included, the delete/close button does not function. On top of this the delete/close will actually submit the form when clicked. This means the button does not only fail to perform its expected behavior, it also has unintended side effects. It's probably best that the button is removed or that a general message header replaces the button. 

This pull request just removes the malfunctioning button.