### PR TITLE
chore: Adjust if template tag

### DIFF
--- a/bulma/templates/pagination.html
+++ b/bulma/templates/pagination.html
@@ -18,7 +18,7 @@
 
   <ul class="pagination-list">
     {% for page in paginator.page_range %}
-      <li><a class="pagination-link{% ifequal page page_obj.number %} is-current{% endifequal %}"
+      <li><a class="pagination-link{% if page page_obj.number %} is-current{% endif %}"
              href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a></li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
On Django 4.0 the {% ifequal %} template tags were officially removed from the codebase. To avoid errors on templates, we need to migrate to the modern {% if %} syntax.

After integrating `django_extensions` in our CI pipeline, the `validate_templates` command now catches this issue explicitly, raising an error whenever deprecated template tags are still present.