### PR TITLE
fix: Add missing expression on if template tag

### DIFF
--- a/bulma/templates/pagination.html
+++ b/bulma/templates/pagination.html
@@ -18,7 +18,7 @@
 
   <ul class="pagination-list">
     {% for page in paginator.page_range %}
-      <li><a class="pagination-link{% if page page_obj.number %} is-current{% endif %}"
+      <li><a class="pagination-link{% if page == page_obj.number %} is-current{% endif %}"
              href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a></li>
     {% endfor %}
   </ul>

--- a/bulma/tests/test_templates.py
+++ b/bulma/tests/test_templates.py
@@ -1,5 +1,7 @@
+from django.core.paginator import Paginator
+
 from bulma.tests.forms import FormExample
-from bulma.tests.utils import render_template
+from bulma.tests.utils import get_dom, render_template
 
 
 def test_bulma_base_template():
@@ -38,3 +40,28 @@ def test_bulma_form_tag():
     )
 
     assert '<div class="field"' in output, "Fields are rendered"
+
+
+def test_pagination_highlights_only_current_page():
+    paginator = Paginator(range(1, 51), 10)  # 50 items, 5 pages
+    page_obj = paginator.get_page(3)
+
+    output = render_template(
+        "{% include 'pagination.html' %}",
+        context={
+            'is_paginated': True,
+            'paginator': paginator,
+            'page_obj': page_obj,
+            'getvars': '',
+            'hashtag': '',
+        }
+    )
+
+    dom = get_dom(output)
+    links = dom.select('a.pagination-link')
+
+    assert len(links) == 5, "Should render 5 page links"
+
+    current_links = [link for link in links if 'is-current' in link.get('class', [])]
+    assert len(current_links) == 1, "Only one page should be marked as current"
+    assert current_links[0].text.strip() == '3', "Page 3 should be the current page"


### PR DESCRIPTION
While reviewing the pagination template, I noticed I missed adding the == comparison operator in my previous [fix](https://github.com/timonweb/django-bulma/pull/98). The `{% if %}` expression was left as:

`{% if page page_obj.number %}`

instead of:

`{% if page == page_obj.number %}`

Without the operator, Django raises a TemplateSyntaxError: Unused 'page_obj.number' at end of if expression, which means the pagination template was completely broken.

This PR fixes the expression and adds a test (`test_pagination_highlights_only_current_page`) that renders the pagination template and asserts only the current page gets the is-current class — so this kind of mistake won't slip through CI again.